### PR TITLE
Remove cabal2nix github dependency

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,14 +2,11 @@ resolver: lts-9.1
 packages:
 - '.'
 - location:
-    git: https://github.com/NixOS/cabal2nix.git
-    commit: 53777ef45c45f397c1f56f9230ae494d2aefee86
-  extra-dep: true
-- location:
     git: https://github.com/fpco/stackage-curator.git
     commit: 3a3feeb6cc9e40bfbd7383c5e8975cd16420d822
   extra-dep: true
 extra-deps:
 - Cabal-2.0.0.2
+- cabal2nix-2.5
 nix:
   packages: [icu openssl zlib]

--- a/stackage2nix.cabal
+++ b/stackage2nix.cabal
@@ -34,7 +34,7 @@ library
                      , QuickCheck
                      , aeson
                      , bytestring
-                     , cabal2nix >= 2.3
+                     , cabal2nix >= 2.5
                      , containers
                      , deepseq
                      , distribution-nixpkgs >= 1.1


### PR DESCRIPTION
cabal2nix 2.5 has been released to the Hackage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/4e6/stackage2nix/26)
<!-- Reviewable:end -->
